### PR TITLE
Fix bug in datasets by drug 

### DIFF
--- a/web-v2/app/api/tools/drug-datasets/route.ts
+++ b/web-v2/app/api/tools/drug-datasets/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request) {
     const onlyGeneExpression = body.onlyGeneExpression === true || body.onlyGeneExpression === "true";
     const maxResults =
       body.maxResults != null && body.maxResults !== ""
-        ? Math.min(500, Math.max(1, Number(body.maxResults) || 500))
+        ? Math.min(500, Math.max(1, Number(body.maxResults) || 200))
         : undefined;
 
     if (drugs.length === 0) {

--- a/web-v2/components/dashboard/SlotForm.tsx
+++ b/web-v2/components/dashboard/SlotForm.tsx
@@ -1641,7 +1641,7 @@ const SLOT_LABELS: Record<string, { label: string; placeholder: string }> = {
     label: "Include MONDO subclasses",
     placeholder: "",
   },
-  max_results: { label: "Maximum results", placeholder: "Default 500" },
+  max_results: { label: "Maximum results", placeholder: "Default 200" },
 };
 
 export function getSlotMeta(varName: string): { label: string; placeholder: string } {
@@ -1926,7 +1926,7 @@ export function SlotForm({
       const rawStr = Array.isArray(raw) ? raw[0] : raw;
       const value = typeof rawStr === "string" && rawStr.trim() !== "" ? rawStr.trim() : "";
       const options = [
-        { value: "", label: "Default (500)" },
+        { value: "", label: "Default (200)" },
         { value: "50", label: "50" },
         { value: "100", label: "100" },
         { value: "200", label: "200" },

--- a/web-v2/lib/agents/query-executor.ts
+++ b/web-v2/lib/agents/query-executor.ts
@@ -1,5 +1,6 @@
 import type { QueryPlan, QueryStep, ExecutionEvent, StepResultContext, Intent, SPARQLResult } from "@/types";
 import type { ContextPack } from "@/lib/context-packs/types";
+import { parseJsonOrThrow, throwForFailedApiResponseWithBody } from "@/lib/http/parse-fetch-json";
 import { generateSPARQLFromIntent } from "@/lib/templates/generator";
 import { resolveEntity, entityResolutionToContext, type EntityResolutionResult } from "./entity-resolver";
 
@@ -484,16 +485,21 @@ async function executeStep(
         }),
     });
 
+    const bodyText = await response.text();
     if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || "SPARQL execution failed");
+        throwForFailedApiResponseWithBody(response, bodyText, "SPARQL execute");
     }
 
-    const result = await response.json();
+    const result = parseJsonOrThrow<{
+        head?: { vars?: string[] };
+        bindings?: SPARQLResult["results"]["bindings"];
+        error?: string;
+    }>(bodyText, response, "SPARQL execute");
     const latency_ms = Date.now() - startTime;
 
+    const headVars = result.head?.vars;
     const sparql_results: SPARQLResult = {
-        head: result.head,
+        head: { vars: Array.isArray(headVars) ? headVars : [] },
         results: {
             bindings: result.bindings || [],
         },

--- a/web-v2/lib/dashboard/drug-datasets-plan.ts
+++ b/web-v2/lib/dashboard/drug-datasets-plan.ts
@@ -22,12 +22,15 @@ LIMIT 50
 
 const MAX_DATASET_RESULTS_CAP = 500;
 
+/** Default NDE row cap when the client does not pass max_results (keeps responses and GXA augment bounded). */
+export const DEFAULT_DRUG_DATASET_LIMIT = 200;
+
 /**
  * Build a fixed 3-step plan: entity resolution (drug name(s) → Wikidata IRIs) →
  * Wikidata (diseases treated by drug + MONDO) → NDE (datasets for those diseases).
  * No LLM; used by the dashboard drug_datasets template.
  * @param drugNames - Drug name(s) to look up
- * @param options - Optional maxResults (capped at MAX_DATASET_RESULTS_CAP), geoOnly (step 3 uses geo_dataset_search)
+ * @param options - Optional maxResults (capped at MAX_DATASET_RESULTS_CAP; omitted uses DEFAULT_DRUG_DATASET_LIMIT), geoOnly (step 3 uses geo_dataset_search)
  */
 export function buildDrugDatasetsPlan(
   drugNames: string[],
@@ -38,7 +41,7 @@ export function buildDrugDatasetsPlan(
   const maxResults =
     options?.maxResults != null && options.maxResults > 0
       ? Math.min(options.maxResults, MAX_DATASET_RESULTS_CAP)
-      : undefined;
+      : DEFAULT_DRUG_DATASET_LIMIT;
   const geoOnly = options?.geoOnly === true;
   const step1Description =
     names.length === 1
@@ -97,7 +100,7 @@ export function buildDrugDatasetsPlan(
         graphs: ["nde"],
         slots: {
           health_conditions: "{{step2.disease_iris}}",
-          ...(maxResults != null ? { limit: maxResults } : {}),
+          limit: maxResults,
         },
         confidence: 1,
         notes: "Dashboard drug_datasets step 3",

--- a/web-v2/lib/dashboard/run-query.ts
+++ b/web-v2/lib/dashboard/run-query.ts
@@ -4,6 +4,7 @@ import type { SPARQLResult } from "@/types";
 import type { MondoExpansionStats } from "@/lib/ontology/mondo-descendants-ols";
 import { ndeBindingHasGeoOrGseEvidence } from "@/lib/dashboard/nde-geo-evidence";
 import { omitUiOnlyOntologyLabelSlots } from "@/lib/dashboard/ui-only-slots";
+import { errorMessageFromFailedApiBody, parseJsonOrThrow } from "@/lib/http/parse-fetch-json";
 
 export const PACK_ID = "wobd";
 
@@ -130,8 +131,28 @@ export async function runTemplateQuery({
       body: JSON.stringify({ drugs, onlyGeneExpression, maxResults }),
       signal,
     });
-    const data = await res.json();
+    const drugBodyText = await res.text();
     if (signal?.aborted) return { results: null, error: "Query was cancelled." };
+    if (!res.ok) {
+      return {
+        results: null,
+        error: errorMessageFromFailedApiBody(res, drugBodyText, "Drug datasets API"),
+      };
+    }
+    let data: {
+      error?: string | null;
+      results?: SPARQLResult | null;
+      filtered_empty_hint?: string;
+      executed_queries?: ExecutedQueryItem[];
+    };
+    try {
+      data = parseJsonOrThrow(drugBodyText, res, "Drug datasets API");
+    } catch (e) {
+      return {
+        results: null,
+        error: e instanceof Error ? e.message : "Invalid response from drug datasets API.",
+      };
+    }
     if (data.error && !data.results) {
       return { results: null, error: data.error };
     }
@@ -154,15 +175,15 @@ export async function runTemplateQuery({
     body: JSON.stringify({ intent, pack_id: PACK_ID }),
     signal,
   });
+  const sparqlBodyText = await sparqlRes.text();
   if (!sparqlRes.ok) {
-    const err = await sparqlRes.json();
-    throw new Error(err.error || "SPARQL generation failed");
+    throw new Error(errorMessageFromFailedApiBody(sparqlRes, sparqlBodyText, "intent-to-sparql API"));
   }
-  const sparqlJson = (await sparqlRes.json()) as {
+  const sparqlJson = parseJsonOrThrow<{
     query?: string;
     mondo_expansion_highlight_labels?: string[];
     mondo_expansion_stats?: Record<string, unknown>;
-  };
+  }>(sparqlBodyText, sparqlRes, "intent-to-sparql API");
   const { query, mondo_expansion_highlight_labels, mondo_expansion_stats } = sparqlJson;
   if (!query) throw new Error("No query returned");
 
@@ -180,13 +201,36 @@ export async function runTemplateQuery({
     }),
     signal,
   });
-  const execData = await execRes.json();
+  const execBodyText = await execRes.text();
 
   if (signal?.aborted) {
     return { results: null, error: "Query was cancelled." };
   }
 
-  if (!execRes.ok || execData.error) {
+  if (!execRes.ok) {
+    return {
+      results: null,
+      error: errorMessageFromFailedApiBody(execRes, execBodyText, "SPARQL execute API"),
+    };
+  }
+
+  let execData: {
+    error?: string;
+    bindings?: SPARQLResult["results"]["bindings"];
+    head?: SPARQLResult["head"];
+    result?: SPARQLResult;
+    executed_query?: string;
+  };
+  try {
+    execData = parseJsonOrThrow(execBodyText, execRes, "SPARQL execute API");
+  } catch (e) {
+    return {
+      results: null,
+      error: e instanceof Error ? e.message : "Invalid response from SPARQL execute API.",
+    };
+  }
+
+  if (execData.error) {
     return {
       results: null,
       error: execData.error || "Query execution failed",

--- a/web-v2/lib/dashboard/run-query.ts
+++ b/web-v2/lib/dashboard/run-query.ts
@@ -123,7 +123,7 @@ export async function runTemplateQuery({
       : slots.max_results;
     const maxResults =
       typeof maxResultsRaw === "string" && maxResultsRaw.trim() !== ""
-        ? Math.min(Math.max(1, parseInt(maxResultsRaw, 10) || 500), 500)
+        ? Math.min(Math.max(1, parseInt(maxResultsRaw, 10) || 200), 500)
         : undefined;
     const res = await fetch("/api/tools/drug-datasets", {
       method: "POST",

--- a/web-v2/lib/http/parse-fetch-json.ts
+++ b/web-v2/lib/http/parse-fetch-json.ts
@@ -1,0 +1,85 @@
+/**
+ * Safe parsing of fetch Response bodies that are expected to be JSON.
+ * Avoids SyntaxError from response.json() when proxies return HTML (502/504 pages).
+ */
+
+function trimPreview(text: string, maxLen: number): string {
+  return text.trim().replace(/\s+/g, " ").slice(0, maxLen);
+}
+
+function bodyLooksLikeHtml(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  if (/^<!doctype\s+html/i.test(t) || /^<html[\s>]/i.test(t)) return true;
+  if (t.startsWith("<") && !/^\s*[\[{]/.test(t)) return true;
+  return false;
+}
+
+/**
+ * Parse JSON from a response body string. Use after reading response.text().
+ * @throws Error with context when body is empty, HTML, or not valid JSON.
+ */
+export function parseJsonOrThrow<T>(bodyText: string, response: Response, context: string): T {
+  const t = bodyText.trim();
+  const { status, statusText } = response;
+  if (!t) {
+    throw new Error(`${context}: empty response body (HTTP ${status} ${statusText}).`);
+  }
+  if (bodyLooksLikeHtml(bodyText)) {
+    throw new Error(
+      `${context}: HTTP ${status} ${statusText} — body was HTML, not JSON (often a reverse-proxy 502/504). Preview: ${trimPreview(t, 200)}…`,
+    );
+  }
+  try {
+    return JSON.parse(bodyText) as T;
+  } catch {
+    throw new Error(
+      `${context}: invalid JSON (HTTP ${status} ${statusText}). Preview: ${trimPreview(t, 200)}…`,
+    );
+  }
+}
+
+/**
+ * Human-readable message for a failed HTTP response body (non-OK or caller-defined).
+ * Use when you should return an error string instead of throwing (e.g. dashboard UI).
+ */
+export function errorMessageFromFailedApiBody(
+  response: Response,
+  bodyText: string,
+  context: string
+): string {
+  const t = bodyText.trim();
+  const { status, statusText } = response;
+  if (!t) {
+    return `${context}: HTTP ${status} ${statusText} (empty body).`;
+  }
+  if (bodyLooksLikeHtml(bodyText)) {
+    return `${context}: HTTP ${status} ${statusText} — body was HTML, not JSON (often a reverse-proxy or gateway timeout). Preview: ${trimPreview(t, 200)}…`;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return `${context}: HTTP ${status} ${statusText} — invalid JSON. Preview: ${trimPreview(t, 200)}…`;
+  }
+  if (parsed && typeof parsed === "object" && "error" in parsed) {
+    const err = (parsed as { error?: unknown }).error;
+    if (typeof err === "string" && err.trim()) {
+      return err.trim();
+    }
+  }
+  return `${context}: HTTP ${status} ${statusText}.`;
+}
+
+/**
+ * For a non-OK HTTP response whose body was already read as text.
+ * Prefers JSON `{ "error": "..." }` when present; otherwise explains HTML/plain failures.
+ * @throws Always (return type never).
+ */
+export function throwForFailedApiResponseWithBody(
+  response: Response,
+  bodyText: string,
+  context: string
+): never {
+  throw new Error(errorMessageFromFailedApiBody(response, bodyText, context));
+}

--- a/web-v2/lib/sparql/executor.ts
+++ b/web-v2/lib/sparql/executor.ts
@@ -1,5 +1,6 @@
 // SPARQL execution against FRINK federation endpoint
 
+import { parseJsonOrThrow } from "@/lib/http/parse-fetch-json";
 import type { SPARQLResult } from "@/types";
 
 const FRINK_FEDERATION_URL = process.env.NEXT_PUBLIC_FRINK_FEDERATION_URL ||
@@ -41,12 +42,15 @@ export async function executeSPARQL(
 
     clearTimeout(timeoutId);
 
+    const bodyText = await response.text();
     if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`SPARQL endpoint error: ${response.status} ${response.statusText}\n${errorText}`);
+      const preview = bodyText.trim().replace(/\s+/g, " ").slice(0, 500);
+      throw new Error(
+        `SPARQL endpoint error: ${response.status} ${response.statusText}${preview ? `\n${preview}` : ""}`,
+      );
     }
 
-    const result: SPARQLResult = await response.json();
+    const result = parseJsonOrThrow<SPARQLResult>(bodyText, response, "SPARQL federation");
     const latency_ms = Date.now() - startTime;
     const row_count = result.results?.bindings?.length || 0;
 


### PR DESCRIPTION
closes https://github.com/SuLab/OKN-WOBD/issues/42

reduced the query limit from 500 to 200, hardened the error response for better debugging and updated the server timeout, see details below:
- in `/etc/nginx/sites-available/okn-wobd-webv2`, add `proxy_read_timeout 600s;` and  `proxy_send_timeout 600s;` into the Web UI configuration block starting with `location / {`. Here is the full settings:
```
location / {
    proxy_pass http://127.0.0.1:3000;
    proxy_http_version 1.1;
    proxy_set_header Host $host;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_read_timeout 600s;
    proxy_send_timeout 600s;
  }
```
- run `sudo nginx -t && sudo systemctl reload nginx`
- reload the server as `sudo systemctl restart okn-wobd-web`